### PR TITLE
feat: accept either cred files or token

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,17 @@ jobs:
 
 | input      | required | default         | description                                                        |
 |------------|----------|-----------------|--------------------------------------------------------------------|
-| key        | ✓        | `-`             | Service Account JSON Key                                           |
+| key        | x        | `-`             | Service Account JSON Key                                           |
+| token      | x        | `-`             | Service Account OIDC token (if using OIDC authn)                   |
 | connection | ✓        | `-`             | Cloud SQL connection name                                          |
 | port       | ✓        | `-`             | *Listening port (MySQL: 3306, PostgreSQL: 5432, SQL Server: 1433)* |
 | version    | ✗        | `1.22.0-alpine` | Cloud SQL Proxy [Version][]                                        |
 | sleep      | ✗        | `3`             | time between connection checks                                     |
-| attempts   | ✗        | `10`            | number of total connection checks                                  |
+| attempts   | x        | `10`            | number of total connection checks                                  |
 
   [Version]: https://github.com/GoogleCloudPlatform/cloudsql-proxy/releases
+
+Note: One of `key` or `token` is required for authentication.
 
 ----
 > Author: [Ahmad Nassri](https://www.ahmadnassri.com/) &bull;

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,14 @@ branding:
 inputs:
   key:
     description: Service Account JSON Key
-    required: true
+    required: false
+
+  token:
+    description: Service Account OIDC Token
+    required: false
 
   connection:
-    description: CloudSQL connection name
+    description: CloudSQL instance connection name, e.g. project:region:instance
     required: true
 
   port:
@@ -21,7 +25,7 @@ inputs:
   version:
     description: CloudSQL Proxy Version
     required: false
-    default: 1.22.0-alpine
+    default: 2.11.3
 
   sleep:
     description: time between connection checks
@@ -40,12 +44,13 @@ runs:
       run: mkdir /tmp/action-google-cloud-sql-proxy
       shell: bash
 
-    - name: "sql-proxy: write key to file"
+    - name: "sql-proxy: write key to file if provided"
+      if: ${{ inputs.key != '' }}
       run: echo '${{ inputs.key }}' > /tmp/action-google-cloud-sql-proxy/key.json
       shell: bash
 
     - name: "sql-proxy: start container"
-      run: ${{ github.action_path }}/scripts/proxy.sh ${{ inputs.version }} ${{ inputs.port }} ${{ inputs.connection }}
+      run: ${{ github.action_path }}/scripts/proxy.sh ${{ inputs.version }} ${{ inputs.port }} ${{ inputs.connection }} ${{ inputs.token }}
       shell: bash
 
     - name: "sql-proxy: wait for connection"

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -2,20 +2,33 @@
 set -euo pipefail
 
 PORT="${2}"
-CONNECTION="${3}"
+INSTANCE_CONNECTION_NAME="${3}"
+TOKEN="${4:-null}"
 DIR="/tmp/action-google-cloud-sql-proxy"
-IMAGE="gcr.io/cloudsql-docker/gce-proxy:${1}"
+IMAGE="gcr.io/cloud-sql-connectors/cloud-sql-proxy:${1}"
 
-# start container
-docker run \
-  --detach \
-  --net host \
-  --restart on-failure \
-  --name cloud-sql-proxy \
-  --publish "${PORT}:${PORT}" \
-  --volume "${DIR}:${DIR}" \
-  "${IMAGE}" \
-  /cloud_sql_proxy \
-  -dir "${DIR}" \
-  -credential_file "${DIR}/key.json" \
-  -instances="${CONNECTION}=tcp:${PORT}"
+if [ $TOKEN = "null" ]; then
+  # use credential file
+  docker run \
+    --detach \
+    --net host \
+    --restart on-failure \
+    --name cloud-sql-proxy \
+    --publish "${PORT}:${PORT}" \
+    --volume "${DIR}:${DIR}" \
+    "${IMAGE}" \
+    ${INSTANCE_CONNECTION_NAME} \
+    --credentials-file "${DIR}/key.json"
+else
+  # use token
+  docker run \
+    --detach \
+    --net host \
+    --restart on-failure \
+    --name cloud-sql-proxy \
+    --publish "${PORT}:${PORT}" \
+    --volume "${DIR}:${DIR}" \
+    "${IMAGE}" \
+    ${INSTANCE_CONNECTION_NAME} \
+    --token "${TOKEN}"
+fi


### PR DESCRIPTION
BREAKING CHANGES: use official docker image and upgrade to v2

Updates to use Docker image from official docs [here](https://cloud.google.com/sql/docs/mysql/connect-auth-proxy#docker) and upgrades the version of the proxy to the latest (v2.11.3).

Relevant issue: https://github.com/ahmadnassri/action-google-cloud-sql-proxy/issues/45