### PR TITLE
Accept GOOGLE_APPLICATION_CREDENTIALS + don't bind host network + use ATTEMPTS parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
 
   [Version]: https://github.com/GoogleCloudPlatform/cloudsql-proxy/releases
 
-Note: One of `key` or `token` is required for authentication.
+Note: One of `key` or `token` parameters or `GOOGLE_APPLICATION_CREDENTIALS` env var set is required for authentication.
 
 ----
 > Author: [Ahmad Nassri](https://www.ahmadnassri.com/) &bull;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Google Cloud SQL Proxy
 
-run the Google Cloud SQL Proxy in a GitHub Action's context
+Run the Google Cloud SQL Proxy in a GitHub Action's context.
 
 [![license][license-img]][license-url]
 [![release][release-img]][release-url]
@@ -11,8 +11,8 @@ run the Google Cloud SQL Proxy in a GitHub Action's context
 
 ### Prerequisites
 
--   Running Cloud SQL instance with a public IP address
--   Service Account with Role `Cloud SQL Client`
+- Running Cloud SQL instance with a public IP address
+- Service Account with Role `Cloud SQL Client`
 
 ``` yaml
 on:
@@ -35,13 +35,13 @@ jobs:
 
 | input      | required | default         | description                                                        |
 |------------|----------|-----------------|--------------------------------------------------------------------|
-| key        | x        | `-`             | Service Account JSON Key                                           |
-| token      | x        | `-`             | Service Account OIDC token (if using OIDC authn)                   |
+| key        | ✗        | `-`             | Service Account JSON Key                                           |
+| token      | ✗        | `-`             | Service Account OIDC token (if using OIDC authn)                   |
 | connection | ✓        | `-`             | Cloud SQL connection name                                          |
 | port       | ✓        | `-`             | *Listening port (MySQL: 3306, PostgreSQL: 5432, SQL Server: 1433)* |
-| version    | ✗        | `1.22.0-alpine` | Cloud SQL Proxy [Version][]                                        |
+| version    | ✗        | `2.11.3`        | Cloud SQL Proxy [Version][]                                        |
 | sleep      | ✗        | `3`             | time between connection checks                                     |
-| attempts   | x        | `10`            | number of total connection checks                                  |
+| attempts   | ✗        | `10`            | number of total connection checks                                  |
 
   [Version]: https://github.com/GoogleCloudPlatform/cloudsql-proxy/releases
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Google Cloud SQL Proxy
 
-Run the Google Cloud SQL Proxy in a GitHub Action's context.
+Run the Google Cloud SQL Proxy in a GitHub Action’s context
 
 [![license][license-img]][license-url]
 [![release][release-img]][release-url]
@@ -33,19 +33,19 @@ jobs:
 
 ### Inputs
 
-| input      | required | default         | description                                                        |
-|------------|----------|-----------------|--------------------------------------------------------------------|
-| key        | ✗        | `-`             | Service Account JSON Key                                           |
-| token      | ✗        | `-`             | Service Account OIDC token (if using OIDC authn)                   |
-| connection | ✓        | `-`             | Cloud SQL connection name                                          |
-| port       | ✓        | `-`             | *Listening port (MySQL: 3306, PostgreSQL: 5432, SQL Server: 1433)* |
-| version    | ✗        | `2.11.3`        | Cloud SQL Proxy [Version][]                                        |
-| sleep      | ✗        | `3`             | time between connection checks                                     |
-| attempts   | ✗        | `10`            | number of total connection checks                                  |
-
-  [Version]: https://github.com/GoogleCloudPlatform/cloudsql-proxy/releases
+| input      | required | default  | description                                                        |
+|------------|----------|----------|--------------------------------------------------------------------|
+| key        | ✗        | `-`      | Service Account JSON Key                                           |
+| token      | ✗        | `-`      | Service Account OIDC token (if using OIDC authentication)          |
+| connection | ✓        | `-`      | Cloud SQL connection name                                          |
+| port       | ✓        | `-`      | *Listening port (MySQL: 3306, PostgreSQL: 5432, SQL Server: 1433)* |
+| version    | ✗        | `2.11.3` | Cloud SQL Proxy [Version][]                                        |
+| sleep      | ✗        | `3`      | time between connection checks                                     |
+| attempts   | ✗        | `10`     | number of total connection checks                                  |
 
 Note: One of `key` or `token` parameters or `GOOGLE_APPLICATION_CREDENTIALS` env var set is required for authentication.
+
+  [Version]: https://github.com/GoogleCloudPlatform/cloudsql-proxy/releases
 
 ----
 > Author: [Ahmad Nassri](https://www.ahmadnassri.com/) &bull;

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: Google Cloud SQL Proxy Action
-description: run the Google Cloud SQL Proxy in a GitHub Action's context
+description: Run the Google Cloud SQL Proxy in a GitHub Action's context
 
 branding:
   icon: database

--- a/colophon.yml
+++ b/colophon.yml
@@ -4,5 +4,5 @@ id: action-google-cloud-sql-proxy
 
 about:
   title: Google Cloud SQL Proxy
-  description: run the Google Cloud SQL Proxy in a GitHub Action's context
+  description: Run the Google Cloud SQL Proxy in a GitHub Action's context
   repository: ahmadnassri/action-google-cloud-sql-proxy

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,11 +26,14 @@ jobs:
 
 | input      | required | default         | description                                                        |
 | ---------- | -------- | --------------- | ------------------------------------------------------------------ |
-| key        | ✓        | `-`             | Service Account JSON Key                                           |
+| key        | ✗        | `-`             | Service Account JSON Key                                           |
+| token      | ✗        | `-`             | Service Account OIDC token (if using OIDC authentication)          |
 | connection | ✓        | `-`             | Cloud SQL connection name                                          |
 | port       | ✓        | `-`             | _Listening port (MySQL: 3306, PostgreSQL: 5432, SQL Server: 1433)_ |
-| version    | ✗        | `1.22.0-alpine` | Cloud SQL Proxy [Version][version]                                 |
+| version    | ✗        | `2.11.3`        | Cloud SQL Proxy [Version][version]                                 |
 | sleep      | ✗        | `3`             | time between connection checks                                     |
 | attempts   | ✗        | `10`            | number of total connection checks                                  |
 
 [version]: https://github.com/GoogleCloudPlatform/cloudsql-proxy/releases
+
+Note: One of `key` or `token` parameters or `GOOGLE_APPLICATION_CREDENTIALS` env var set is required for authentication.

--- a/docs/README.template
+++ b/docs/README.template
@@ -4,6 +4,8 @@ $about.description$
 
 [![license][license-img]][license-url]
 [![release][release-img]][release-url]
+[![super linter][super-linter-img]][super-linter-url]
+[![semantic][semantic-img]][semantic-url]
 
 $body$
 
@@ -16,3 +18,9 @@ $body$
 
 [release-url]: https://github.com/$about.repository$/releases
 [release-img]: https://badgen.net/github/release/$about.repository$
+
+[super-linter-url]: https://github.com/ahmadnassri/action-google-cloud-sql-proxy/actions?query=workflow%3Asuper-linter
+[super-linter-img]: https://github.com/ahmadnassri/action-google-cloud-sql-proxy/workflows/super-linter/badge.svg
+
+[semantic-url]: https://github.com/ahmadnassri/action-google-cloud-sql-proxy/actions?query=workflow%3Arelease
+[semantic-img]: https://badgen.net/badge/📦/semantically%20released/blue

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -10,6 +10,8 @@ IMAGE="gcr.io/cloud-sql-connectors/cloud-sql-proxy:${1}"
 
 if [ $IMPLICIT_CREDENTIALS != "null" ]; then
   echo "Starting proxy using GOOGLE_APPLICATION_CREDENTIALS"
+  # make sure the container user will be permitted to use the JSON key file
+  chmod a+r $GOOGLE_APPLICATION_CREDENTIALS
   docker run \
     --detach \
     --restart on-failure \

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -16,9 +16,9 @@ if [ $TOKEN = "null" ]; then
     --publish "127.0.0.1:${PORT}:${PORT}" \
     --volume "${DIR}:${DIR}" \
     "${IMAGE}" \
-    --address=0.0.0.0 \
-    --credentials-file "${DIR}/key.json" \
-    ${INSTANCE_CONNECTION_NAME}
+    ${INSTANCE_CONNECTION_NAME} \
+    --address 0.0.0.0 \
+    --credentials-file "${DIR}/key.json"
 else
   # use token
   docker run \
@@ -27,7 +27,7 @@ else
     --name cloud-sql-proxy \
     --publish "127.0.0.1:${PORT}:${PORT}" \
     "${IMAGE}" \
-    --address=0.0.0.0 \
-    --token "${TOKEN}" \
-    ${INSTANCE_CONNECTION_NAME}
+    ${INSTANCE_CONNECTION_NAME} \
+    --address 0.0.0.0 \
+    --token "${TOKEN}"
 fi

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -13,19 +13,21 @@ if [ $TOKEN = "null" ]; then
     --detach \
     --restart on-failure \
     --name cloud-sql-proxy \
-    --publish "${PORT}:${PORT}" \
+    --publish "127.0.0.1:${PORT}:${PORT}" \
     --volume "${DIR}:${DIR}" \
     "${IMAGE}" \
-    ${INSTANCE_CONNECTION_NAME} \
-    --credentials-file "${DIR}/key.json"
+    --address=0.0.0.0 \
+    --credentials-file "${DIR}/key.json" \
+    ${INSTANCE_CONNECTION_NAME}
 else
   # use token
   docker run \
     --detach \
     --restart on-failure \
     --name cloud-sql-proxy \
-    --publish "${PORT}:${PORT}" \
+    --publish "127.0.0.1:${PORT}:${PORT}" \
     "${IMAGE}" \
-    ${INSTANCE_CONNECTION_NAME} \
-    --token "${TOKEN}"
+    --address=0.0.0.0 \
+    --token "${TOKEN}" \
+    ${INSTANCE_CONNECTION_NAME}
 fi

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -8,7 +8,7 @@ IMPLICIT_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS:-null}"
 DIR="/tmp/action-google-cloud-sql-proxy"
 IMAGE="gcr.io/cloud-sql-connectors/cloud-sql-proxy:${1}"
 
-if [ $TOKEN != "null" ]; then
+if [ "$TOKEN" != "null" ]; then
   echo "Starting proxy using token"
   docker run \
     --detach \
@@ -16,7 +16,7 @@ if [ $TOKEN != "null" ]; then
     --name cloud-sql-proxy \
     --publish "127.0.0.1:${PORT}:${PORT}" \
     "${IMAGE}" \
-    ${INSTANCE_CONNECTION_NAME} \
+    "${INSTANCE_CONNECTION_NAME}" \
     --address 0.0.0.0 \
     --token "${TOKEN}"
 elif [ -e ${DIR}/key.json ]; then
@@ -28,13 +28,13 @@ elif [ -e ${DIR}/key.json ]; then
     --publish "127.0.0.1:${PORT}:${PORT}" \
     --volume "${DIR}:${DIR}" \
     "${IMAGE}" \
-    ${INSTANCE_CONNECTION_NAME} \
+    "${INSTANCE_CONNECTION_NAME}" \
     --address 0.0.0.0 \
     --credentials-file "${DIR}/key.json"
-elif [ $IMPLICIT_CREDENTIALS != "null" ]; then
+elif [ "$IMPLICIT_CREDENTIALS" != "null" ]; then
   echo "Starting proxy using GOOGLE_APPLICATION_CREDENTIALS"
   # make sure the container user will be permitted to use the JSON key file
-  chmod a+r $GOOGLE_APPLICATION_CREDENTIALS
+  chmod a+r "$GOOGLE_APPLICATION_CREDENTIALS"
   docker run \
     --detach \
     --restart on-failure \
@@ -42,7 +42,7 @@ elif [ $IMPLICIT_CREDENTIALS != "null" ]; then
     --publish "127.0.0.1:${PORT}:${PORT}" \
     --volume "${IMPLICIT_CREDENTIALS}:${IMPLICIT_CREDENTIALS}" \
     "${IMAGE}" \
-    ${INSTANCE_CONNECTION_NAME} \
+    "${INSTANCE_CONNECTION_NAME}" \
     --address 0.0.0.0 \
     --credentials-file "${IMPLICIT_CREDENTIALS}"
 else

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -8,7 +8,30 @@ IMPLICIT_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS:-null}"
 DIR="/tmp/action-google-cloud-sql-proxy"
 IMAGE="gcr.io/cloud-sql-connectors/cloud-sql-proxy:${1}"
 
-if [ $IMPLICIT_CREDENTIALS != "null" ]; then
+if [ $TOKEN != "null" ]; then
+  echo "Starting proxy using token"
+  docker run \
+    --detach \
+    --restart on-failure \
+    --name cloud-sql-proxy \
+    --publish "127.0.0.1:${PORT}:${PORT}" \
+    "${IMAGE}" \
+    ${INSTANCE_CONNECTION_NAME} \
+    --address 0.0.0.0 \
+    --token "${TOKEN}"
+elif [ -e ${DIR}/key.json ]; then
+  echo "Starting proxy using credentials file"
+  docker run \
+    --detach \
+    --restart on-failure \
+    --name cloud-sql-proxy \
+    --publish "127.0.0.1:${PORT}:${PORT}" \
+    --volume "${DIR}:${DIR}" \
+    "${IMAGE}" \
+    ${INSTANCE_CONNECTION_NAME} \
+    --address 0.0.0.0 \
+    --credentials-file "${DIR}/key.json"
+elif [ $IMPLICIT_CREDENTIALS != "null" ]; then
   echo "Starting proxy using GOOGLE_APPLICATION_CREDENTIALS"
   # make sure the container user will be permitted to use the JSON key file
   chmod a+r $GOOGLE_APPLICATION_CREDENTIALS
@@ -22,27 +45,7 @@ if [ $IMPLICIT_CREDENTIALS != "null" ]; then
     ${INSTANCE_CONNECTION_NAME} \
     --address 0.0.0.0 \
     --credentials-file "${IMPLICIT_CREDENTIALS}"
-elif [ $TOKEN = "null" ]; then
-  echo "Starting proxy using credentials file"
-  docker run \
-    --detach \
-    --restart on-failure \
-    --name cloud-sql-proxy \
-    --publish "127.0.0.1:${PORT}:${PORT}" \
-    --volume "${DIR}:${DIR}" \
-    "${IMAGE}" \
-    ${INSTANCE_CONNECTION_NAME} \
-    --address 0.0.0.0 \
-    --credentials-file "${DIR}/key.json"
 else
-  echo "Starting proxy using token"
-  docker run \
-    --detach \
-    --restart on-failure \
-    --name cloud-sql-proxy \
-    --publish "127.0.0.1:${PORT}:${PORT}" \
-    "${IMAGE}" \
-    ${INSTANCE_CONNECTION_NAME} \
-    --address 0.0.0.0 \
-    --token "${TOKEN}"
+  echo "Couldn't find valid credentials!"
+  exit 1
 fi

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -4,11 +4,24 @@ set -euo pipefail
 PORT="${2}"
 INSTANCE_CONNECTION_NAME="${3}"
 TOKEN="${4:-null}"
+IMPLICIT_CREDENTIALS="${GOOGLE_APPLICATION_CREDENTIALS:-null}"
 DIR="/tmp/action-google-cloud-sql-proxy"
 IMAGE="gcr.io/cloud-sql-connectors/cloud-sql-proxy:${1}"
 
-if [ $TOKEN = "null" ]; then
-  # use credential file
+if [ $IMPLICIT_CREDENTIALS != "null" ]; then
+  echo "Starting proxy using GOOGLE_APPLICATION_CREDENTIALS"
+  docker run \
+    --detach \
+    --restart on-failure \
+    --name cloud-sql-proxy \
+    --publish "127.0.0.1:${PORT}:${PORT}" \
+    --volume "${IMPLICIT_CREDENTIALS}:${IMPLICIT_CREDENTIALS}" \
+    "${IMAGE}" \
+    ${INSTANCE_CONNECTION_NAME} \
+    --address 0.0.0.0 \
+    --credentials-file "${IMPLICIT_CREDENTIALS}"
+elif [ $TOKEN = "null" ]; then
+  echo "Starting proxy using credentials file"
   docker run \
     --detach \
     --restart on-failure \
@@ -20,7 +33,7 @@ if [ $TOKEN = "null" ]; then
     --address 0.0.0.0 \
     --credentials-file "${DIR}/key.json"
 else
-  # use token
+  echo "Starting proxy using token"
   docker run \
     --detach \
     --restart on-failure \

--- a/scripts/proxy.sh
+++ b/scripts/proxy.sh
@@ -11,7 +11,6 @@ if [ $TOKEN = "null" ]; then
   # use credential file
   docker run \
     --detach \
-    --net host \
     --restart on-failure \
     --name cloud-sql-proxy \
     --publish "${PORT}:${PORT}" \
@@ -23,11 +22,9 @@ else
   # use token
   docker run \
     --detach \
-    --net host \
     --restart on-failure \
     --name cloud-sql-proxy \
     --publish "${PORT}:${PORT}" \
-    --volume "${DIR}:${DIR}" \
     "${IMAGE}" \
     ${INSTANCE_CONNECTION_NAME} \
     --token "${TOKEN}"

--- a/scripts/wait.sh
+++ b/scripts/wait.sh
@@ -19,8 +19,5 @@ for (( ATTEMPT=1; ATTEMPT<=$ATTEMPTS; ATTEMPT++ )); do
   echo "connection not available, sleeping for ${SLEEP} seconds. Recent container logs:"
   docker logs --timestamps --since=${SLEEP}s cloud-sql-proxy
 
-  # Debug
-  cat /tmp/action-google-cloud-sql-proxy/key.json
-
   sleep "${SLEEP}"
 done

--- a/scripts/wait.sh
+++ b/scripts/wait.sh
@@ -6,7 +6,7 @@ PORT="${1}"
 SLEEP="${2}"
 ATTEMPTS="${3}"
 
-for ATTEMPT in {1..10}; do
+for (( ATTEMPT=1; ATTEMPT<=$ATTEMPTS; ATTEMPT++ )); do
   echo "connection attempt $ATTEMPT/$ATTEMPTS"
 
   READY=$(bash -c 'exec 3<> /dev/tcp/127.0.0.1/'"${PORT}"';echo $?' 2>/dev/null)
@@ -16,8 +16,11 @@ for ATTEMPT in {1..10}; do
     break
   fi
 
-  echo "connection not available, sleeping for ${SLEEP} seconds. Container logs:"
+  echo "connection not available, sleeping for ${SLEEP} seconds. Recent container logs:"
   docker logs --timestamps --since=${SLEEP}s cloud-sql-proxy
+
+  # Debug
+  cat /tmp/action-google-cloud-sql-proxy/key.json
 
   sleep "${SLEEP}"
 done

--- a/scripts/wait.sh
+++ b/scripts/wait.sh
@@ -16,7 +16,8 @@ for ATTEMPT in {1..10}; do
     break
   fi
 
-  echo "connection not available, sleeping for ${SLEEP} seconds"
+  echo "connection not available, sleeping for ${SLEEP} seconds. Container logs:"
+  docker logs --timestamps --since=${SLEEP}s cloud-sql-proxy
 
   sleep "${SLEEP}"
 done


### PR DESCRIPTION
I had a bit of a nightmare getting this action going, but while debugging to make it work I found a few things to improve on:
- use `attempts` parameter in the `wait.sh` loop – currently it's hardcoded to 10
- if `GOOGLE_APPLICATION_CREDENTIALS` env var is present use it, so if you use `google-github-actions/auth@v2` this action will "just work" without any config
- print authentication method so you know which one was picked by the condition
- remove volume when authenticating with token as it's not used
- stop binding to host network and also limit port binding to connections from localhost to make it simpler and more secure
- print container logs if connection wasn't successful to help with debugging
- minor edits in README
- improve conditions for auth checking so that it actually checks if the credentials file exists and prints an error message if can't find any of the 3 auth options